### PR TITLE
Custom name of cookie for session

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -109,7 +109,7 @@ return [
     |
     */
 
-    'cookie' => 'laravel_session',
+    'cookie' => env('SESSION_DRIVER', 'laravel_session'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Add the option to set a custom name of the cookie for session in the environment file configuration, by default accept the name of 'laravel_session'

  'cookie' => env('SESSION_DRIVER', 'laravel_session'),